### PR TITLE
merge mbedtls_3.6_sgx

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,9 @@
-# ⚠️ Project Maintenance Notice
+# mbedtls-SGX: a TLS stack in SGX
+## ✅ Maintained by Safeheron
 
-> **This project is a maintained fork of [mbedtls-SGX](https://github.com/bl4ck5un/mbedtls-SGX)**.
+> Safeheron has adopted and now actively maintains this fork of **[mbedtls-SGX](https://github.com/bl4ck5un/mbedtls-SGX)**, which was previously unmaintained. As part of its mission to support the SGX open-source ecosystem, Safeheron is advancing SGX-based TLS development with a focus on transparency and security.
 
-The original repository has not been actively maintained in recent years. To continue support for SGX-based TLS development, **Safeheron** has taken over maintenance and further development of this project.
-
-## ✅ Enhancements by Safeheron
-
-Safeheron has contributed the following major improvements:
+### Key Enhancements by Safeheron
 
 - **Upgraded mbedtls to [v3.6.3](https://github.com/Mbed-TLS/mbedtls/releases/tag/v3.6.3)**. Updated to the latest version to support modern TLS features, stay current with upstream security fixes, and mitigate vulnerabilities present in older versions — ensuring long-term security support.
 
@@ -18,11 +15,11 @@ Safeheron has contributed the following major improvements:
 
 This version brings the project up to date with current SGX and TLS best practices.
 
-> 📌 For existing users of the original mbedtls-SGX, we strongly recommend migrating to this maintained version to ensure compatibility with modern SGX development practices, improved performance, and up-to-date TLS security guarantees.
+> ⚠️ For existing users of the original mbedtls-SGX, we strongly recommend migrating to this maintained version to ensure compatibility with modern SGX development practices, improved performance, and up-to-date TLS security guarantees.
 
 ---
 
-# mbedtls-SGX: a TLS stack in SGX
+## Overview
 
 mbedtls-SGX is a port of [mbedtls](https://github.com/ARMmbed/mbedtls) (previously PolarSSL) to Intel-SGX. mbedtls-SGX aims to preserve **all** of the [features of mbedtls](https://tls.mbed.org/core-features). With mbedtls-SGX, you can
 
@@ -49,16 +46,16 @@ mbedtls-SGX is a static enclave library. General steps of using mbedtls-SGX in y
 ## Build
 
 ```
-git clone https://github.com/bl4ck5un/mbedtls-SGX && cd mbedtls-SGX
+git clone https://github.com/Safeheron/mbedtls-SGX && cd mbedtls-SGX
 mkdir build && cd build
 cmake ..
 make -j && make install
 ```
 
-Include the resultant `mbedtls_SGX-2.6.0` as part of your project.
+Include the resultant `mbedtls_SGX-3.6.3` as part of your project.
 
 ```
-mbedtls_SGX-2.6.0
+mbedtls_SGX-3.6.3
 ├── include
 │   └── mbedtls
 └── lib
@@ -79,15 +76,14 @@ make -j
 
 Three examples will be built
 
-- `s_client`: a simple TLS client (by default it connects to `google.com:443`, dumps the HTML page and exits)
-- `s_server`: a simple TLS server. You can play with it by `openssl s_client localhost:4433`.
-- `m_server`: a multi-threaded TLS server, also listening at `localhost:4433` by default.
+- `c1_client`: a simple TLS client (by default it connects to `google.com:443`, dumps the HTML page and exits)
+- `c2_client`: a simple TLS client (by default it connects to `localhost:4433`, dumps the HTML page and exits)
+- `c2_server`: a multi-threaded TLS server, also listening at `localhost:4433` by default.
 
 # Missing features and workarounds
 
 Due to SGX's contraints, some features have been turned off.
 
-- The lack of trusted wall-clock time. SGX provides trusted relative timer but not an absolute one. This affects checking expired certificates. A workaround is to maintain an internal clock and calibrate it frequently.
 - No access to file systems: mbedtls-SGX can not load CA files from file systems. To work this around, you need to hardcode root CAs as part of the enclave program. See `example/enclave/ca_bundle.h` for an example.
 
 # License

--- a/example/enclave/case_1/c1_ssl_client.c
+++ b/example/enclave/case_1/c1_ssl_client.c
@@ -185,7 +185,7 @@ int c1_ssl_client_main(void)
      */
     mbedtls_printf("  > Write to server:\n\n");
 
-    len = sprintf((char *) buf, GET_REQUEST);
+    len = snprintf((char *) buf, sizeof buf, GET_REQUEST);
 
     while ((ret = mbedtls_ssl_write(&ssl, buf, len)) <= 0) {
         if (ret != MBEDTLS_ERR_SSL_WANT_READ && ret != MBEDTLS_ERR_SSL_WANT_WRITE) {

--- a/ocall/std_ocalls.c
+++ b/ocall/std_ocalls.c
@@ -1,7 +1,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-int ocall_print_string(const char *str)
+int ocall_mbedtls_print_string(const char *str)
 {
     /* Proxy/Bridge will check the length and null-terminate 
      * the input string to prevent buffer overflow. 

--- a/trusted/glue.c
+++ b/trusted/glue.c
@@ -27,7 +27,7 @@
 #include "mbedtls_SGX_t.h"
 
 // real ocall to be implemented in the Application
-int printf_sgx(const char *fmt, ...)
+int mbedtls_sgx_printf(const char *fmt, ...)
 {
     int ret;
     va_list ap;
@@ -36,7 +36,7 @@ int printf_sgx(const char *fmt, ...)
     vsnprintf(buf, BUFSIZ, fmt, ap);
     va_end(ap);
 
-    ocall_print_string(&ret, buf);
+    ocall_mbedtls_print_string(&ret, buf);
     return ret;
 }
 
@@ -46,7 +46,7 @@ int mbedtls_hardware_poll(void *data, unsigned char *output, size_t len, size_t 
     (void)data;
     sgx_status_t st = sgx_read_rand(output, len);
     if (st != SGX_SUCCESS) {
-        printf_sgx("hardware_poll fails with %d\n", st);
+        mbedtls_sgx_printf("hardware_poll fails with %d\n", st);
         *olen = -1;
         return -1;
     }
@@ -60,13 +60,13 @@ int mbedtls_hardware_poll(void *data, unsigned char *output, size_t len, size_t 
 int mbedtls_sgx_drbg_random( void *p_rng, unsigned char *output, size_t out_len )
 {
     if (!output) {
-        printf_sgx("mbedtls_sgx_drbg receives NULL");
+        mbedtls_sgx_printf("mbedtls_sgx_drbg receives NULL");
         return -1;
     }
     (void)p_rng;
     sgx_status_t st = sgx_read_rand(output, out_len);
     if (st != SGX_SUCCESS) {
-        printf_sgx("mbedtls_sgx_drbg fails with %d\n", st);
+        mbedtls_sgx_printf("mbedtls_sgx_drbg fails with %d\n", st);
         return -1;
     }
 

--- a/trusted/mbedtls-3.6.3/include/glue.h
+++ b/trusted/mbedtls-3.6.3/include/glue.h
@@ -28,7 +28,7 @@ extern "C" {
 
 int mbedtls_sgx_drbg_random( void *p_rng, unsigned char *output, size_t out_len );
 int mbedtls_hardware_poll(void *data, unsigned char *output, size_t len, size_t *olen );
-int printf_sgx(const char *fmt, ...);
+int mbedtls_sgx_printf(const char *fmt, ...);
 void mbedtls_sgx_exit(int exit_code);
 
 

--- a/trusted/mbedtls-3.6.3/include/mbedtls/mbedtls_config.h
+++ b/trusted/mbedtls-3.6.3/include/mbedtls/mbedtls_config.h
@@ -4114,7 +4114,7 @@
 //#define MBEDTLS_PLATFORM_TIME_TYPE_MACRO       time_t /**< Default time macro to use, can be undefined. MBEDTLS_HAVE_TIME must be enabled */
 //#define MBEDTLS_PLATFORM_FPRINTF_MACRO      fprintf /**< Default fprintf macro to use, can be undefined */
 #include "glue.h"
-#define MBEDTLS_PLATFORM_PRINTF_MACRO        printf_sgx /**< Default printf macro to use, can be undefined */
+#define MBEDTLS_PLATFORM_PRINTF_MACRO        mbedtls_sgx_printf /**< Default printf macro to use, can be undefined */
 //#define MBEDTLS_PLATFORM_PRINTF_MACRO        printf /**< Default printf macro to use, can be undefined */
 /* Note: your snprintf must correctly zero-terminate the buffer! */
 //#define MBEDTLS_PLATFORM_SNPRINTF_MACRO    snprintf /**< Default snprintf macro to use, can be undefined */

--- a/trusted/mbedtls_SGX.edl
+++ b/trusted/mbedtls_SGX.edl
@@ -29,7 +29,7 @@ enclave {
         void ocall_mbedtls_gmtime_r([in] int64_t *unix_time, [out] struct tm *result);
 
         // printf
-        int ocall_print_string([in, string] const char *str);
+        int ocall_mbedtls_print_string([in, string] const char *str);
 
         // exit
         void ocall_mbedtls_exit(int exit_code);


### PR DESCRIPTION
Avoid potential name conflicts
    
1. Rename:
    printf_sgx => mbedtls_sgx_printf
    ocall_print_string => ocall_mbedtls_print_string
    
2. Replace snprintf with sprintf in example.
    
3. Update README.md